### PR TITLE
8flix extract

### DIFF
--- a/transcribers/flix.py
+++ b/transcribers/flix.py
@@ -63,25 +63,6 @@ class FlixExtractor(Transcriber):
         pdf_soup = BeautifulSoup(e.content)
         buttons = pdf_soup.select(BUTTONS_CSS_SELECTOR)
         self.pdf_url = BASE_URL + buttons[PDF_BUTTON_INDEX]['href']
-
-    def debug(self):
-        # Extract text from PDF
-        transcript = get_pdf_text(self.pdf_url)
-
-        # Strip stage directions
-        stage_dir_re = re.compile(STAGE_DIRECTIONS_REGEX)
-        transcript = stage_dir_re.sub(' ', transcript)
-
-        # Strip end timestamps
-        end_stamp_re = re.compile(END_TIMESTAMP_REGEX)
-        transcript = end_stamp_re.sub('', transcript)
-
-        transcript_list = re.split(BLOCK_NUMBER_REGEX, transcript)
-
-        # Remove intro text from generated timestamp-text pairs
-        transcript_list.pop(0)
-        print(transcript_list)
-
         
     
     def getTranscript(self):


### PR DESCRIPTION
Fixed a critical logical error in flix.py which truncated the wrong side of text, resulting in transcripts including random numericals (from the timestamp) or getting words cut off